### PR TITLE
fix: update GH Action to commit changes after generating docs

### DIFF
--- a/.github/workflows/spectaql.yml
+++ b/.github/workflows/spectaql.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     types:
       - closed
+    branches:
+      - 'main'
 
 jobs:
   build-and-deploy:
@@ -20,6 +22,12 @@ jobs:
           npm ci
           npm run augment-schema
           npm run generate-docs
+
+      - name: Commit Docs
+        uses: EndBug/add-and-commit@v9
+        id: commit_branch
+        with:
+          message: 'Updating Documentation HTML and Schema'
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@3.6.2


### PR DESCRIPTION
Continued work for [CLM-7395](https://thoughtindustries.atlassian.net/browse/CLM-7395?atlOrigin=eyJpIjoiMGVjZTA4YTEzZjEyNGIxNWFjZDc2ZmU5Njg2NzljMDUiLCJwIjoiaiJ9).

`JamesIves/github-pages-deploy-action@3.6.2` reinitializes the action repo and fetches `main`. The expected HTML changes from `npm run generate-docs` weren't `committed` so docs were published with the pre-merge schema and not updated. Change includes step to commit changes after generating docs.